### PR TITLE
Cubase Dongle Support

### DIFF
--- a/AtariST.sv
+++ b/AtariST.sv
@@ -649,25 +649,26 @@ end
 //////////////////////////////////////////////////////////////////////////////////
 
 // enable additional ste/megaste features
-wire       MEM512K      = (status[3:1] == 3'd0);
-wire       MEM1M        = (status[3:1] == 3'd1);
-wire       MEM2M        = (status[3:1] == 3'd2);
-wire       MEM4M        = (status[3:1] == 3'd3);
-wire       MEM8M        = (status[3:1] == 3'd4);
-wire       MEM14M       = (status[3:1] == 3'd5);
-wire [1:0] fdc_wp       = status[7:6];
-wire       mono_monitor = status[8];
-wire [8:0] acsi_enable  = status[17:10];
-wire       blitter_en   = (status[19] || ste);
-wire [1:0] scanlines    = status[21:20];
-wire       psg_stereo   = status[22];
-wire       ste          = status[23] || status[24];
-wire       mste         = status[24];
-wire       steroids     = status[23] && status[24];  // a STE on steroids
-wire       viking_en    = status[28];
-wire       narrow_brd   = status[29];
-wire       mde60        = status[30];
-wire [1:0] ar           = {status[31],status[9]};
+wire       MEM512K       = (status[3:1] == 3'd0);
+wire       MEM1M         = (status[3:1] == 3'd1);
+wire       MEM2M         = (status[3:1] == 3'd2);
+wire       MEM4M         = (status[3:1] == 3'd3);
+wire       MEM8M         = (status[3:1] == 3'd4);
+wire       MEM14M        = (status[3:1] == 3'd5);
+wire [1:0] fdc_wp        = status[7:6];
+wire       mono_monitor  = status[8];
+wire [8:0] acsi_enable   = status[17:10];
+wire       blitter_en    = (status[19] || ste);
+wire [1:0] scanlines     = status[21:20];
+wire       psg_stereo    = status[22];
+wire       ste           = status[23] || status[24];
+wire       mste          = status[24];
+wire       steroids      = status[23] && status[24];  // a STE on steroids
+wire       viking_en     = status[28];
+wire       narrow_brd    = status[29];
+wire       mde60         = status[30];
+wire [1:0] ar            = {status[31],status[9]};
+wire       cubase_enable = 1'b1; //status[32];
 
 // synchronized reset signal
 reg reset;
@@ -731,6 +732,7 @@ assign      cpu_din =
               blitter_sel ? blitter_data_out :
               !rdat_n  ? shifter_dout :
               !(mfpcs_n & mfpiack_n)? { 8'hff, mfp_data_out } :
+              (!rom3_n & cubase_enable) ? {7'h7f, cubase_d8, 8'hff } :
               !rom_n   ? rom_data_out :
               n6850    ? { mbus_a[2] ? midi_acia_data_out : kbd_acia_data_out, 8'hFF } :
               sndcs    ? { snd_data_out, 8'hFF }:
@@ -1399,6 +1401,19 @@ fdc1772 #(.IMG_TYPE(1)) fdc1772 (
 	.sd_dout        ( sd_buff_dout     ),
 	.sd_din         ( sd_buff_din      ),
 	.sd_dout_strobe ( sd_buff_wr       )
+);
+
+/* ------------------------------------------------------------------------------ */
+/* ------------------------------- Cubase dongle  ------------------------------- */
+/* ------------------------------------------------------------------------------ */
+wire cubase_d8;
+
+cubase_dongle cubase_dongle (
+	.clk        ( clk_32    ),
+	.reset      ( peripheral_reset ),
+	.rom3_n     ( rom3_n    ),
+	.a8         ( mbus_a[8] ),
+	.d8         ( cubase_d8 )
 );
 
 /* ------------------------------------------------------------------------------ */

--- a/rtl/cubase_dongle.v
+++ b/rtl/cubase_dongle.v
@@ -1,0 +1,216 @@
+module cubase_dongle (
+	input clk,
+	input reset, // POR actually
+	input rom3_n,
+	input a8,
+	output reg d8
+);
+
+//File generated from rainbow unicorn farts
+//
+//From the source file SRD_OK.JED
+//
+//No rights reserved
+//
+//Device 5c060
+// pin02          = 2
+// pin03          = 3
+// pin04          = 4
+// pin05          = 5
+// pin06          = 6
+// pin07          = 7
+// pin08          = 8
+// pin09          = 9
+// pin10          = 10
+// pin11          = 11
+// pin14          = 14
+// pin15          = 15
+// pin16          = 16
+// pin17          = 17
+// pin18          = 18
+// pin19          = 19
+// pin20          = 20
+// pin21          = 21
+// pin22          = 22
+// pin23          = 23
+//
+//turbo
+//
+//start
+//
+// pin03          ^:=  /pin03*/pin14
+//                 +   pin03* pin14;
+//
+// pin04          ^:=  /pin04* pin14
+//                 +   pin03*/pin04*/pin14
+//                 +   pin03* pin04* pin14;
+//
+// pin05          ^:=   pin03*/pin05* pin14
+//                 +   pin04* pin05* pin14
+//                 +   pin03* pin04*/pin05*/pin14;
+//
+// pin06          ^:=   pin03*/pin06*/pin14
+//                 +   pin04*/pin05* pin06
+//                 +   pin03* pin04* pin05*/pin06*/pin14;
+//
+// pin07          ^:=  /pin03* pin05*/pin07
+//                 +  /pin04*/pin06* pin07* pin14
+//                 +   pin03* pin04* pin05* pin06*/pin07*/pin14;
+//
+// pin08          ^:=  /pin03*/pin05* pin07*/pin08
+//                 +  /pin04* pin06* pin08* pin14
+//                 +   pin03* pin04* pin05* pin06* pin07*/pin08*/pin14;
+//
+// pin09          ^:=  /pin07* pin08*/pin09
+//                 +   pin04*/pin05*/pin06* pin09
+//                 +   pin03* pin04* pin05* pin06* pin07* pin08*/pin09*/pin14;
+//
+// pin10          ^:=  /pin04* pin07*/pin08*/pin10
+//                 +   pin05* pin06*/pin09* pin10
+//                 +   pin03* pin04* pin05* pin06* pin07* pin08* pin09*/pin10*/pin14;
+//
+// pin15          ^:=  /pin07* pin08*/pin15
+//                 +  /pin06* pin09*/pin10* pin15
+//                 +   pin03* pin04* pin05* pin06* pin07* pin08* pin09* pin10*/pin14*/pin15;
+//
+// pin16          ^:=  /pin09*/pin15* pin16
+//                 +  /pin08* pin10*/pin16
+//                 +   pin03* pin04* pin05* pin06* pin07* pin08* pin09* pin10*/pin14* pin15*/pin16;
+//
+// pin17          ^:=  /pin08* pin17
+//                 +  /pin10*/pin16*/pin17
+//                 +   pin03* pin04* pin05* pin06* pin07* pin08* pin09* pin10*/pin14* pin15* pin16*/pin17;
+//
+// pin18          ^:=  /pin15* pin16* pin18
+//                 +   pin08*/pin10* pin17*/pin18
+//                 +   pin03* pin04* pin05* pin06* pin07* pin08* pin09* pin10*/pin14* pin15* pin16* pin17*/pin18;
+//
+// pin19          ^:=   pin10*/pin15*/pin19
+//                 +   pin16*/pin17* pin18* pin19
+//                 +   pin03* pin04* pin05* pin06* pin07* pin08* pin09* pin10*/pin14* pin15* pin16* pin17* pin18*/pin19;
+//
+// pin20          ^:=  /pin16*/pin19*/pin20
+//                 +   pin17*/pin18* pin20
+//                 +   pin03* pin04* pin05* pin06* pin07* pin08* pin09* pin10*/pin14* pin15* pin16* pin17* pin18* pin19*/pin20;
+//
+// pin21          ^:=  /pin17* pin18*/pin21
+//                 +  /pin16* pin19*/pin20* pin21
+//                 +   pin03* pin04* pin05* pin06* pin07* pin08* pin09* pin10*/pin14* pin15* pin16* pin17* pin18* pin19* pin20*/pin21;
+//
+// pin22.ena       =  /pin02;
+// pin22          ^:=  /pin04* pin22
+//                 +   pin05* pin14*/pin22
+//                 +   pin09*/pin14*/pin16*/pin18* pin22
+//                 +  /pin06* pin09* pin14* pin17*/pin21* pin22
+//                 +   pin03* pin04* pin05* pin06* pin07* pin08* pin09* pin10*/pin14* pin15* pin16* pin17* pin18* pin19* pin20* pin21*/pin22;
+//
+//
+//end
+
+reg pin03;
+reg pin04;
+reg pin05;
+reg pin06;
+reg pin07;
+reg pin08;
+reg pin09;
+reg pin10;
+reg pin15;
+reg pin16;
+reg pin17;
+reg pin18;
+reg pin19;
+reg pin20;
+reg pin21;
+
+reg rom3_nD;
+always @(posedge clk) begin
+	rom3_nD <= rom3_n;
+	if (reset) begin
+		pin03 <= 0;
+		pin04 <= 0;
+		pin05 <= 0;
+		pin06 <= 0;
+		pin07 <= 0;
+		pin08 <= 0;
+		pin09 <= 0;
+		pin10 <= 0;
+		pin16 <= 0;
+		pin17 <= 0;
+		pin18 <= 0;
+		pin19 <= 0;
+		pin20 <= 0;
+		pin21 <= 0;
+		d8 <= 0;
+	end
+	else
+	if (rom3_n & !rom3_nD) begin
+		pin03 <= pin03 ^ ( (!pin03&!a8)
+		                   | (pin03& a8));
+
+		pin04 <= pin04 ^ ( ((!pin04& a8)
+		                   |  ( pin03&!pin04&!a8)
+		                   |  ( pin03& pin04& a8)));
+
+		pin05 <= pin05 ^ ( (( pin03&!pin05& a8)
+		                   |  ( pin04& pin05& a8)
+		                   |  ( pin03& pin04&!pin05&!a8)));
+
+		pin06 <= pin06 ^ ( (( pin03&!pin06&!a8)
+		                   |  ( pin04&!pin05& pin06)
+		                   |  ( pin03& pin04& pin05&!pin06&!a8)));
+
+		pin07 <= pin07 ^ ( ((!pin03& pin05&!pin07)
+		                   |  (!pin04&!pin06& pin07& a8)
+		                   |  ( pin03& pin04& pin05& pin06&!pin07&!a8)));
+
+		pin08 <= pin08 ^ ( ((!pin03&!pin05& pin07&!pin08)
+		                   |  (!pin04& pin06& pin08& a8)
+		                   |  ( pin03& pin04& pin05& pin06& pin07&!pin08&!a8)));
+
+		pin09 <= pin09 ^ ( ((!pin07& pin08&!pin09)
+		                   |  ( pin04&!pin05&!pin06& pin09)
+		                   |  ( pin03& pin04& pin05& pin06& pin07& pin08&!pin09&!a8)));
+
+		pin10 <= pin10 ^ ( ((!pin04& pin07&!pin08&!pin10)
+		                   |  ( pin05& pin06&!pin09& pin10)
+		                   |  ( pin03& pin04& pin05& pin06& pin07& pin08& pin09&!pin10&!a8)));
+
+		pin15 <= pin15 ^ (  ((!pin07& pin08&!pin15)
+		                   |  (!pin06& pin09&!pin10& pin15)
+		                   |  ( pin03& pin04& pin05& pin06& pin07& pin08& pin09& pin10&!a8&!pin15)));
+
+		pin16 <= pin16 ^ (  ((!pin09&!pin15& pin16)
+		                   |  (!pin08& pin10&!pin16)
+		                   |  ( pin03& pin04& pin05& pin06& pin07& pin08& pin09& pin10&!a8& pin15&!pin16)));
+
+		pin17 <= pin17 ^ ( ((!pin08& pin17)
+		                   |  (!pin10&!pin16&!pin17)
+		                   |  ( pin03& pin04& pin05& pin06& pin07& pin08& pin09& pin10&!a8& pin15& pin16&!pin17)));
+
+		pin18 <= pin18 ^ (  ((!pin15& pin16& pin18)
+		                   |  ( pin08&!pin10& pin17&!pin18)
+		                   |  ( pin03& pin04& pin05& pin06& pin07& pin08& pin09& pin10&!a8& pin15& pin16& pin17&!pin18)));
+
+		pin19 <= pin19 ^ (  (( pin10&!pin15&!pin19)
+		                   |  ( pin16&!pin17& pin18& pin19)
+		                   |  ( pin03& pin04& pin05& pin06& pin07& pin08& pin09& pin10&!a8& pin15& pin16& pin17& pin18&!pin19)));
+
+		pin20 <= pin20 ^ (  ((!pin16&!pin19&!pin20)
+		                   |  ( pin17&!pin18& pin20)
+		                   |  ( pin03& pin04& pin05& pin06& pin07& pin08& pin09& pin10&!a8& pin15& pin16& pin17& pin18& pin19&!pin20)));
+
+		pin21 <= pin21 ^ (  ((!pin17& pin18&!pin21)
+		                   |  (!pin16& pin19&!pin20& pin21)
+		                   |  ( pin03& pin04& pin05& pin06& pin07& pin08& pin09& pin10&!a8& pin15& pin16& pin17& pin18& pin19& pin20&!pin21)));
+
+		d8          <= d8 ^ (  (!pin04& d8)
+		                   |  ( pin05& a8&!d8)
+		                   |  ( pin09&!a8&!pin16&!pin18& d8)
+		                   |  (!pin06& pin09& a8& pin17&!pin21& d8)
+		                   |  ( pin03& pin04& pin05& pin06& pin07& pin08& pin09& pin10&!a8& pin15& pin16& pin17& pin18& pin19& pin20& pin21&!d8));
+	end
+
+end
+
+endmodule


### PR DESCRIPTION
Request support for cubase dongle. Permanently enabled in this PR. It appeared that main had no more room for options. Please consider integrating and adding a toggle in the OSD. Cubase dongle is fully functional in the build below.

[AtariST_cubase.zip](https://github.com/MiSTer-devel/AtariST_MiSTer/files/8402946/AtariST_cubase.zip)
